### PR TITLE
Respond to close instead of exit events

### DIFF
--- a/lib/gpg.js
+++ b/lib/gpg.js
@@ -30,7 +30,7 @@ var GPG = {
    * @param {Function} Optional callback
    * @api public
    */
-  
+
   encryptToFile: function(options, fn){
     options = options || {};
 
@@ -47,7 +47,7 @@ var GPG = {
           , destStream = writeStream(options.dest)
           , gpg = spawn('gpg', ['--encrypt']);
 
-        gpg.on('exit', function (code){
+        gpg.on('close', function (code){
           fn.call(null, null);
         });
 
@@ -66,7 +66,7 @@ var GPG = {
    * @param {Function} Optional callback containing the encrypted file contents.
    * @api public
    */
-  
+
   encryptFile: function(file, fn){
     var self = this;
 
@@ -75,7 +75,7 @@ var GPG = {
         fn.call(null, err, data);
       });
     });
-  }, 
+  },
 
   /**
    * Encrypt string `str` and pass the encrypted version to the callback `fn`.
@@ -94,26 +94,26 @@ var GPG = {
     } else {
       args = defaultArgs.concat(args);
     }
-    
+
     var buffers = []
       , buffersLength = 0
       , error = ''
       , gpg = spawn('gpg', args);
-    
+
     gpg.stdout.on('data', function (buf){
       buffers.push(buf);
       buffersLength += buf.length;
     });
-    
+
     gpg.stderr.on('data', function(buf){
       error += buf.toString('utf8');
     });
-    
-    gpg.on('exit', function (code){
+
+    gpg.on('close', function (code){
       if (code !== 0) {
         return fn.call(null, new Error(error));
       }
-            
+
       // concatenate all buffers together
       var buffer = new Buffer(buffersLength)
         , targetStart = 0;
@@ -124,7 +124,7 @@ var GPG = {
       fn.call(null, null, buffer);
     });
 
-    gpg.stdin.end(str);
+    gpg.stdin.end(str, 'utf8');
   },
 
   /**
@@ -144,26 +144,26 @@ var GPG = {
     } else {
       args = defaultArgs.concat(args);
     }
-    
+
     var buffers = []
       , buffersLength = 0
       , error = ''
       , gpg = spawn('gpg', args);
-    
+
     gpg.stdout.on('data', function (buf){
       buffers.push(buf);
       buffersLength += buf.length;
     });
-    
+
     gpg.stderr.on('data', function (data){
       error += data.toString('utf8');
     });
-    
-    gpg.on('exit', function (code){
+
+    gpg.on('close', function (code){
       if (code !== 0){
         return fn.call(null, new Error(error));
       }
-      
+
       // concatenate all buffers together
       var buffer = new Buffer(buffersLength)
         , targetStart = 0;
@@ -219,7 +219,7 @@ var GPG = {
           , destStream = writeStream(options.dest)
           , gpg = spawn('gpg', ['--decrypt']);
 
-        gpg.on('exit', function (code){
+        gpg.on('close', function (code){
           fn.call(null, null);
         });
 
@@ -229,17 +229,17 @@ var GPG = {
         fn.call(null, new Error(options.source + ' does not exist'));
       }
     });
-  }, 
-  
+  },
+
   /**
    * Clearsign `str` and pass the signed message to the callback `fn`.
-   * 
+   *
    * @param {String|Buffer} str
    * @param {Array} args Optional additional arguments to pass to gpg.
    * @param {Function} callback containing the signed message Buffer.
    * @api public
    */
-  
+
   clearsign: function(str, args, fn){
     var defaultArgs = globalArgs.concat(['--clearsign']);
     if (typeof args === 'function'){
@@ -248,26 +248,26 @@ var GPG = {
     } else {
       args = defaultArgs.concat(args);
     }
-    
+
     var buffers = []
       , buffersLength = 0
       , error = ''
       , gpg = spawn('gpg', args);
-      
+
     gpg.stdout.on('data', function(buf){
       buffers.push(buf);
       buffersLength += buf.length;
     });
-    
+
     gpg.stderr.on('data', function(data){
       error += data.toString('utf8');
     });
-    
-    gpg.on('exit', function(code){
+
+    gpg.on('close', function(code){
       if (code !== 0) {
         return fn.call(null, new Error(error));
       }
-      
+
       // concatenate all buffers together
       var buffer = new Buffer(buffersLength)
         , targetStart = 0;
@@ -275,13 +275,13 @@ var GPG = {
         b.copy(buffer, targetStart);
         targetStart += b.length
       });
-      
+
       fn.call(null, null, buffer);
     });
-    
+
     gpg.stdin.end(str);
   }
-  
+
 };
 
 /**


### PR DESCRIPTION
I observed a race condition when observing the 'exit' instead of
the 'close' event. Sometimes encryption would work, sometimes it
wouldn't. Debugging showed that the 'exit' event is sometimes
called before a 'data' event arrives.

The Node.js documentation actually states such behavior:

  Event: 'exit'
  Note that the child process stdio streams might still be open.
  http://nodejs.org/api/child_process.html#child_process_event_exit

  Event: 'close'
  This event is emitted when the stdio streams of a child process
  have all terminated. This is distinct from 'exit', since multiple
  processes might share the same stdio streams.
  http://nodejs.org/api/child_process.html#child_process_event_close

This commit switches from the 'exit' to 'close' events.
