### PR TITLE
Added stderr output as additional callback parameter

### DIFF
--- a/lib/spawnGPG.js
+++ b/lib/spawnGPG.js
@@ -44,7 +44,7 @@ module.exports = function(input, defaultArgs, args, cb) {
       return cb(new Error(error || msg));
     }
 
-    cb(null, msg);
+    cb(null, msg, error);
   });
 
   gpg.stdin.end(input);

--- a/test/index.js
+++ b/test/index.js
@@ -125,6 +125,14 @@ describe('gpg', function(){
       });
     });
 
+    it('should provide stderr output for successful calls', function(done) {
+      gpg.decrypt(encryptedString, function(err, decrypted, stderr){
+        assert.ok(/ID C343C0BC/.test(stderr)); // key information is sent to stderr by gpg
+        assert.equal(decrypted.toString('utf8'), 'Hello World');
+        done();
+      });
+    });
+
     it('should decrypt Buffers', function(done){
       var encryptedBuffer = new Buffer(encryptedString);
       gpg.decrypt(encryptedBuffer, function(err, decrypted){

--- a/test/index.js
+++ b/test/index.js
@@ -127,6 +127,7 @@ describe('gpg', function(){
 
     it('should provide stderr output for successful calls', function(done) {
       gpg.decrypt(encryptedString, function(err, decrypted, stderr){
+        assert.ifError(err);
         assert.ok(/ID C343C0BC/.test(stderr)); // key information is sent to stderr by gpg
         assert.equal(decrypted.toString('utf8'), 'Hello World');
         done();


### PR DESCRIPTION
gpg sends some additional information to stderr even if everything was fine. For example the key verification information during decryption.
To provide access to this information without redirecting it to stdout this change adds the "error" as a third parameter to the callback function.
This allows users to get the decrypted content and the additional information separately if needed.

### My usecase: 
I wanted to review the key verification information during decryption.
```
gpg: encrypted with 2048-bit RSA key, ID C343C0BC, created 2015-06-01
      "Node-GPG Test Key (Keypair used for node-gpg testing.) <test@test.com>"
```
currently this information is not accessible through node-gpg as stderr is ignored when the call to gpq was successful. One solution would be to redirect stderr to stdout but this would change the decryption result and add this additional information. 
To solve this this PR adds the error as a third parameter to the callback that can be used or not and should not affect any backwards compatibility.

### Usage: 

```js
gpg.decrypt(encryptedString, function(err, decrypted, stderr) {
  console.log(err);
  console.log(decrypted);
  console.log(stderr); 
});
```