### PR TITLE
Fixing regex

### DIFF
--- a/lib/gpg.js
+++ b/lib/gpg.js
@@ -9,7 +9,7 @@
  */
 var fs = require('fs');
 var spawnGPG = require('./spawnGPG');
-var keyRegex = /^gpg: key (.*?):/;
+var keyRegex = /gpg: key (.*?):/;
 
 /**
  * Base `GPG` object.


### PR DESCRIPTION
This regex works fine when the importKey function updates a key that already exists but fails when the key is imported for the first time.