### PR TITLE
added piping exception handling

### DIFF
--- a/lib/spawnGPG.js
+++ b/lib/spawnGPG.js
@@ -105,8 +105,8 @@ module.exports.streaming = function(options, args, cb) {
   }
 
   // Pipe input file into gpg stdin; gpg stdout into output file..
-  sourceStream.pipe(gpg.stdin);
-  gpg.stdout.pipe(destStream);
+  sourceStream.pipe(gpg.stdin).on('error', cb);
+  gpg.stdout.pipe(destStream).on('error', cb);
 };
 
 // Wrapper around spawn. Catches error events and passed global args.


### PR DESCRIPTION
was getting this unhandled exception:

`events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at exports._errnoException (util.js:1020:11)
    at WriteWrap.afterWrite (net.js:800:14)`

After this little fix I can handle the error in the callback.