### PR TITLE
Change keyRegex to match keyID with extra output in stdout

### DIFF
--- a/lib/gpg.js
+++ b/lib/gpg.js
@@ -9,7 +9,7 @@
  */
 var fs = require('fs');
 var spawnGPG = require('./spawnGPG');
-var keyRegex = /^gpg: key (.*?):/;
+var keyRegex = /gpg: key (.*?):/;
 
 /**
  * Base `GPG` object.


### PR DESCRIPTION
## Context

The issue is related to fresh deployments only. The problem is current import function expects clean STDOUT for import call, like:

```
gpg: key 123123A1A1: public key \"Eldar <keyowner@test.com>\" imported\ngpg: Total number processed: 1\ngpg:               imported: 1  (RSA: 1)\n
```

But in case of fresh deployments of container with just installed gpg, first run of gpg would print additional data:

```
gpg: directory `/home/user/.gnupg' created\ngpg: new configuration file `/home/user/.gnupg/gpg.conf' created\ngpg: WARNING: options in `/home/user/.gnupg/gpg.conf' are not yet active during this run\ngpg: keyring `/home/user/.gnupg/secring.gpg' created\ngpg: keyring `/home/user/.gnupg/pubring.gpg' created\ngpg: /home/user/.gnupg/trustdb.gpg: trustdb created\ngpg: key 123123A1A1: public key \"Eldar <keyowner@test.com>\" imported\ngpg: Total number processed: 1\ngpg:               imported: 1  (RSA: 1)\n
```

In that case, import function would not throw any errors, but would resolve keyId value as `null`. Later it could result in errors during encryption, like:

```
Error: gpg:  null: skipped: No public key
gpg: [stdin]: encryption failed: No public key
```

## Changes

- Remove `^` from keyRegex